### PR TITLE
Handle non-ascii slugs

### DIFF
--- a/apps/firestorm_web/assets/.gitignore
+++ b/apps/firestorm_web/assets/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/apps/firestorm_web/lib/firestorm_web/web/controllers/post_controller.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/controllers/post_controller.ex
@@ -15,7 +15,7 @@ defmodule FirestormWeb.Web.PostController do
           nil ->
             conn
             |> put_flash(:error, "No such thread")
-            |> redirect(to: category_path(conn, :show, category.id))
+            |> redirect(to: category_path(conn, :show, category_finder(category)))
           thread ->
             apply(__MODULE__, action_name(conn),
               [conn, conn.params, category, thread])
@@ -54,7 +54,7 @@ defmodule FirestormWeb.Web.PostController do
           {:ok, _} ->
             conn
             |> put_flash(:info, "Post created successfully")
-            |> redirect(to: category_thread_path(conn, :show, category.slug, thread.id))
+            |> redirect(to: category_thread_path(conn, :show, category_finder(category), thread.id))
 
           {:error, changeset} ->
             conn

--- a/apps/firestorm_web/lib/firestorm_web/web/controllers/thread_controller.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/controllers/thread_controller.ex
@@ -11,7 +11,8 @@ defmodule FirestormWeb.Web.ThreadController do
   alias FirestormData.Followable
 
   def action(conn, _) do
-    case GetCategory.run(%GetCategory{finder: conn.params["category_id"]}) do
+    finder = get_finder(conn.params["category_id"])
+    case GetCategory.run(%GetCategory{finder: finder}) do
       {:ok, category} ->
         apply(__MODULE__, action_name(conn),
           [conn, conn.params, category])
@@ -54,7 +55,7 @@ defmodule FirestormWeb.Web.ThreadController do
       {:error, :not_found} ->
         conn
         |> put_flash(:error, "No such thread")
-        |> redirect(to: category_path(conn, :show, category.slug))
+        |> redirect(to: category_path(conn, :show, category_finder(category)))
     end
   end
 
@@ -83,7 +84,7 @@ defmodule FirestormWeb.Web.ThreadController do
           {:ok, thread_id} ->
             conn
             |> put_flash(:info, "Thread created successfully")
-            |> redirect(to: category_thread_path(conn, :show, category.slug, thread_id))
+            |> redirect(to: category_thread_path(conn, :show, category_finder(category), thread_id))
 
           {:error, changeset} ->
             conn
@@ -109,18 +110,18 @@ defmodule FirestormWeb.Web.ThreadController do
           {:ok, _} ->
             conn
             |> put_flash(:info, "You are now following this thread")
-            |> redirect(to: category_thread_path(conn, :show, category.slug, id_or_slug))
+            |> redirect(to: category_thread_path(conn, :show, category_finder(category), id_or_slug))
 
           {:error, _} ->
             conn
             |> put_flash(:error, "An error occurred")
-            |> redirect(to: category_thread_path(conn, :show, category.slug, id_or_slug))
+            |> redirect(to: category_thread_path(conn, :show, category_finder(category), id_or_slug))
         end
 
       {:error, :not_found} ->
         conn
         |> put_flash(:error, "No such thread")
-        |> redirect(to: category_thread_path(conn, :show, category.slug, id_or_slug))
+        |> redirect(to: category_thread_path(conn, :show, category_finder(category), id_or_slug))
     end
   end
 
@@ -137,13 +138,13 @@ defmodule FirestormWeb.Web.ThreadController do
           :ok ->
             conn
             |> put_flash(:info, "You are no longer following this thread")
-            |> redirect(to: category_thread_path(conn, :show, category.slug, id_or_slug))
+            |> redirect(to: category_thread_path(conn, :show, category_finder(category), id_or_slug))
         end
 
       {:error, :not_found} ->
         conn
         |> put_flash(:error, "No such thread")
-        |> redirect(to: category_thread_path(conn, :show, category.slug, id_or_slug))
+        |> redirect(to: category_thread_path(conn, :show, category_finder(category), id_or_slug))
     end
   end
 

--- a/apps/firestorm_web/lib/firestorm_web/web/templates/category/show.html.haml
+++ b/apps/firestorm_web/lib/firestorm_web/web/templates/category/show.html.haml
@@ -8,7 +8,7 @@
         %i.fa.fa-plus
         New Category
     %li
-      %a.pure-button.button-primary{href: "#{category_thread_path(@conn, :new, @category.slug)}"}
+      %a.pure-button.button-primary{href: "#{category_thread_path(@conn, :new, category_finder(@category))}"}
         %i.fa.fa-plus
         New Thread
 

--- a/apps/firestorm_web/lib/firestorm_web/web/templates/post/new.html.haml
+++ b/apps/firestorm_web/lib/firestorm_web/web/templates/post/new.html.haml
@@ -1,6 +1,6 @@
 %h2 New Post
 
-- form_for @changeset, category_thread_post_path(@conn, :create, @category.slug, @thread.id), [class: "post-editor"], fn f ->
+- form_for @changeset, category_thread_post_path(@conn, :create, category_finder(@category), @thread.id), [class: "post-editor"], fn f ->
   = textarea f, :body, class: "autoexpand", "data-min-rows": 4, rows: 4
 
   .action-bar
@@ -8,7 +8,7 @@
       %button.pure-button.button-primary.-inverted.attachment
         %i.fa.fa-paperclip
     .end
-      %a.pure-button.button-primary.-muted.cancel{href: "#{category_thread_path(@conn, :show, @category.slug, @thread.id)}"}
+      %a.pure-button.button-primary.-muted.cancel{href: "#{category_thread_path(@conn, :show, category_finder(@category), @thread.id)}"}
         Cancel
       %button.pure-button.button-primary.reply{type: "submit"}
         %i.fa.fa-mail-reply

--- a/apps/firestorm_web/lib/firestorm_web/web/templates/thread/_first_post.html.haml
+++ b/apps/firestorm_web/lib/firestorm_web/web/templates/thread/_first_post.html.haml
@@ -13,14 +13,14 @@
         - # LOL this path is stupid, but I don't see how to do proper non-REST member actions yet in
         - #the phoenix router DSL and there aren't any examples in Phoenix's test suite that I can find.
         - if @following do
-          %a{href: "#{category_thread_thread_path(@conn, :unfollow, @category.slug, @thread.id)}"}
+          %a{href: "#{category_thread_thread_path(@conn, :unfollow, category_finder(@category), @thread.id)}"}
             %i.fa.fa-eye.-highlight
         - else
-          %a{href: "#{category_thread_thread_path(@conn, :follow, @category.slug, @thread.id)}"}
+          %a{href: "#{category_thread_thread_path(@conn, :follow, category_finder(@category), @thread.id)}"}
             %i.fa.fa-eye
       %li
         %a{href: "#"}
           %i.fa.fa-quote-right
       %li
-        %a{href: "#{category_thread_post_path(@conn, :new, @category.slug, @thread.id)}"}
+        %a{href: "#{category_thread_post_path(@conn, :new, category_finder(@category), @thread.id)}"}
           %i.fa.fa-reply

--- a/apps/firestorm_web/lib/firestorm_web/web/templates/thread/_post.html.haml
+++ b/apps/firestorm_web/lib/firestorm_web/web/templates/thread/_post.html.haml
@@ -16,5 +16,5 @@
         %a{href: "#"}
           %i.fa.fa-quote-right
       %li
-        %a{href: "#{category_thread_post_path(@conn, :new, @category.slug, @thread.id)}"}
+        %a{href: "#{category_thread_post_path(@conn, :new, category_finder(@category), @thread.id)}"}
           %i.fa.fa-reply

--- a/apps/firestorm_web/lib/firestorm_web/web/templates/thread/new.html.haml
+++ b/apps/firestorm_web/lib/firestorm_web/web/templates/thread/new.html.haml
@@ -1,6 +1,6 @@
 %h2 Start a new thread
 
-- form_for @changeset, category_thread_path(@conn, :create, @category.slug), [class: 'new-thread'], fn f ->
+- form_for @changeset, category_thread_path(@conn, :create, category_finder(@category)), [class: 'new-thread'], fn f ->
   = text_input f, :title, placeholder: "Type a title"
   = textarea f, :body, placeholder: "Type thread content here. Use markdown syntax.", class: "autoexpand", rows: 4, "data-min-rows": 4
 
@@ -9,7 +9,7 @@
       %button.pure-button.button-primary.-inverted.attachment{type: "submit"}
         %i.fa.fa-paperclip
     .end
-      %a.pure-button.button-primary.-muted.cancel{href: "#{category_path(@conn, :show, @category.slug)}"}
+      %a.pure-button.button-primary.-muted.cancel{href: "#{category_path(@conn, :show, category_finder(@category))}"}
         Cancel
       %button.pure-button.button-primary.reply
         %i.fa.fa-plus

--- a/apps/firestorm_web/lib/firestorm_web/web/views/link_helpers.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/views/link_helpers.ex
@@ -4,20 +4,21 @@ defmodule FirestormWeb.Web.LinkHelpers do
   """
 
   import FirestormWeb.Web.Router.Helpers
+  import FirestormWeb.Web.SlugHelpers
   import Phoenix.HTML.{Link, Tag}
 
   @doc """
   Link to a thread using the thread's title as the link text
   """
   def thread_title_link(conn, thread) do
-    link thread.title, to: category_thread_path(conn, :show, thread.category.slug, thread.id), class: "title"
+    link thread.title, to: category_thread_path(conn, :show, category_finder(thread.category), thread.id), class: "title"
   end
 
   @doc """
   Link to a category using the category's title as the link text
   """
   def category_title_link(conn, category) do
-    link category.title, to: category_path(conn, :show, category.slug)
+    link category.title, to: category_path(conn, :show, category_finder(category))
   end
 
   def user_link(user) do

--- a/apps/firestorm_web/lib/firestorm_web/web/views/slug_helpers.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/views/slug_helpers.ex
@@ -1,0 +1,12 @@
+defmodule FirestormWeb.Web.SlugHelpers do
+  @moduledoc """
+  View helpers for working with slugs.
+  """
+  def slugged_finder(nil, id), do: id
+  def slugged_finder("", id), do: id
+  def slugged_finder(slug, _), do: slug
+
+  def category_finder(category) do
+    slugged_finder(category.slug, category.id)
+  end
+end

--- a/apps/firestorm_web/lib/firestorm_web/web/views/thread_view.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/views/thread_view.ex
@@ -1,6 +1,7 @@
 defmodule FirestormWeb.Web.ThreadView do
   use FirestormWeb.Web, :view
   alias FirestormData.Thread
+  import FirestormWeb.Web.SlugHelpers
 
   def user(thread) do
     {:ok, user} = Thread.user(thread)
@@ -15,7 +16,7 @@ defmodule FirestormWeb.Web.ThreadView do
 
   def back("show.html", conn) do
     category = conn.assigns[:category]
-    category_path(conn, :show, category.slug)
+    category_path(conn, :show, category_finder(category))
   end
   def back(_template, _conn), do: nil
 

--- a/apps/firestorm_web/lib/firestorm_web/web/web.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/web.ex
@@ -37,6 +37,9 @@ defmodule FirestormWeb.Web do
 
       # Import slug helpers
       import FirestormWeb.Web.ControllerHelpers.Slugs
+      # Oops we have a 'view' version and a 'controller' version and they're
+      # schizophrenic - we should integrate them at some point.
+      import FirestormWeb.Web.SlugHelpers
     end
   end
 
@@ -61,24 +64,25 @@ defmodule FirestormWeb.Web do
         FormHelpers,
         ErrorHelpers,
         Gettext,
-        ViewHelpers,
-        Router.Helpers,
         LinkHelpers,
+        Router.Helpers,
+        SlugHelpers,
         TagHelpers,
+        ViewHelpers,
       }
 
       alias FirestormData.{
         Category,
+        Post,
+        Repo,
         Thread,
         User,
-        Post,
-        Repo
       }
 
       alias FirestormWeb.Web.{
         CategoryView,
+        LayoutView,
         ThreadView,
-        LayoutView
       }
 
       # Our navigation view defaults


### PR DESCRIPTION
Add a helper to choose to use the slug or the id depending on the value
of the slug - this helps us short-circuit titles that result in an empty
slug, while also giving us an extra layer of abstraction and flexibility
regarding URLs. Fixes #4