### PR TITLE
Specify order for home categories

### DIFF
--- a/apps/firestorm_data/lib/firestorm_data/commands/get_home_categories.ex
+++ b/apps/firestorm_data/lib/firestorm_data/commands/get_home_categories.ex
@@ -13,6 +13,7 @@ defmodule FirestormData.Commands.GetHomeCategories do
     categories =
       Category.roots
       |> preload([threads: [posts: [:user], category: []], parent: []])
+      |> order_by(:inserted_at)
       |> Repo.all
       |> Enum.map(&add_children/1)
 

--- a/apps/firestorm_web/test/controllers/api/v1/home_controller_test.exs
+++ b/apps/firestorm_web/test/controllers/api/v1/home_controller_test.exs
@@ -36,14 +36,14 @@ defmodule FirestormWeb.Web.Api.V1.HomeControllerTest do
         |> hd
       assert first_category_first_thread["user_id"] == knewter.id
       assert length(first_category_first_thread["post_ids"]) == 1
-      assert first_category_first_thread["title"] == "First elm thread"
+      assert first_category_first_thread["title"] == "First elixir thread"
       first_category_first_thread_first_post_id = hd(first_category_first_thread["post_ids"])
       posts = response["posts"]
       first_category_first_thread_first_post =
         posts
         |> Enum.filter(fn(p) -> p["id"] == first_category_first_thread_first_post_id end)
         |> hd
-      assert first_category_first_thread_first_post["body"] == "This is some content for the first elm thread post"
+      assert first_category_first_thread_first_post["body"] == "This is some content for the first elixir thread post"
       first_category_first_thread_first_post_user_id = first_category_first_thread_first_post["user_id"]
       users = response["users"]
       first_category_first_thread_first_post_user =


### PR DESCRIPTION
NOTE: this is just to fix a non-deterministic test for now. This should
actually order categories and subcategories and threads by post recency.