### PR TITLE
human readable oauth error message

### DIFF
--- a/apps/firestorm_web/lib/firestorm_web/web/controllers/auth_controller.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/controllers/auth_controller.ex
@@ -40,6 +40,7 @@ defmodule FirestormWeb.Web.AuthController do
           end
         else
           %{ email: email } -> show_github_oauth_required_field_error(conn, "username")
+        end
     end
   end
 

--- a/apps/firestorm_web/lib/firestorm_web/web/controllers/auth_controller.ex
+++ b/apps/firestorm_web/lib/firestorm_web/web/controllers/auth_controller.ex
@@ -20,24 +20,32 @@ defmodule FirestormWeb.Web.AuthController do
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     case auth.provider do
       :github ->
-        %{name: name, nickname: nickname, email: email} = auth.info
+        with %{name: name, nickname: nickname, email: email} <- auth.info do
 
-        changeset =
-          %LoginOrRegisterFromGitHub{}
-          |> LoginOrRegisterFromGitHub.changeset(%{username: nickname, name: name, email: email})
+          changeset =
+            %LoginOrRegisterFromGitHub{}
+            |> LoginOrRegisterFromGitHub.changeset(%{username: nickname, name: name, email: email})
 
-        case LoginOrRegisterFromGitHub.run(changeset) do
-          {:ok, user} ->
-            conn
-            |> put_flash(:info, "Successfully authenticated.")
-            |> put_session(:current_user, user.id)
-            |> redirect(to: "/")
+          case LoginOrRegisterFromGitHub.run(changeset) do
+            {:ok, user} ->
+              conn
+              |> put_flash(:info, "Successfully authenticated.")
+              |> put_session(:current_user, user.id)
+              |> redirect(to: "/")
 
-          {:error, changeset} ->
-            conn
-            |> put_flash(:error, inspect changeset)
-            |> redirect(to: "/")
-        end
+            {:error, changeset} ->
+              conn
+              |> put_flash(:error, inspect changeset)
+              |> redirect(to: "/")
+          end
+        else
+          %{ email: email } -> show_github_oauth_required_field_error(conn, "username")
     end
+  end
+
+  defp show_github_oauth_required_field_error(conn, field) do
+    conn
+    |> put_flash(:error, "#{field} is a required field. Please make sure your Github profile has made #{field} publicly viewable before attempting to log in again")
+    |> redirect(to: "/")
   end
 end


### PR DESCRIPTION
I faced a confusing error message when initially attempting to authenticate through github oauth. The `inspect  changeset` error message that gets spit out isn't very readable, and it took me about 3-4 minutes to realize that I probably had hidden my email on my github profile.

Instead of catching the error from the changeset validation, this PR uses `with` to check the required fields and then `put_flash`es a more human readable message based on the missing field

I apologize if I didn't follow some of the internal conventions you guys might follow in terms of contributing. If you'd like, I would be more than happy to help out / maybe fill out some of the documentation to help more people contribute, although I should warn you I'm not the most experienced with Elixir (I'm a node and recently a ruby dev mainly), but I'm liking it a lot so far