### PR TITLE
Fix GitHub login

### DIFF
--- a/lib/firestorm_web/forums/forums.ex
+++ b/lib/firestorm_web/forums/forums.ex
@@ -479,6 +479,14 @@ defmodule FirestormWeb.Forums do
     |> ThreadTitleSlug.unique_constraint
   end
 
+  def login_or_register_from_github(%{nickname: nickname, name: nil, email: _email} = user) do
+    login_or_register_from_github(%{user | name: nickname})
+  end
+
+  def login_or_register_from_github(%{nickname: nickname, name: _name, email: nil} = user) do
+    login_or_register_from_github(%{user | email: nickname <> "@users.noreply.github.com"})
+  end
+
   def login_or_register_from_github(%{nickname: nickname, name: name, email: email}) do
     case get_user_by_username(nickname) do
       nil ->

--- a/test/forums_test.exs
+++ b/test/forums_test.exs
@@ -232,15 +232,29 @@ defmodule FirestormWeb.ForumsTest do
     assert user == Forums.get_user_by_username(user.username)
   end
 
-  test "login_or_register_from_github/1 returns a user after creating one" do
-    auth_info = %{
-      name: "Josh Adams",
-      nickname: "knewter",
-      email: "josh@dailydrip.com"
-    }
-    result = Forums.login_or_register_from_github(auth_info)
-    assert {:ok, user} = result
-    assert user.email == "josh@dailydrip.com"
+  describe "login_or_register_from_github/1 returns a user after creating one" do
+    test "when the user has name and public email on GitHub" do
+      auth_info = %{
+        name: "Josh Adams",
+        nickname: "knewter",
+        email: "josh@dailydrip.com"
+      }
+      result = Forums.login_or_register_from_github(auth_info)
+      assert {:ok, user} = result
+      assert user.email == "josh@dailydrip.com"
+    end
+
+    test "when the user doesn't have name and public email on GitHub" do
+      auth_info = %{
+        name: nil,
+        nickname: "knewter",
+        email: nil,
+      }
+      result = Forums.login_or_register_from_github(auth_info)
+      assert {:ok, user} = result
+      assert user.name == "knewter"
+      assert user.email == "knewter@users.noreply.github.com"
+    end
   end
 
   test "login_or_register_from_github/1 returns a user if it already exists" do


### PR DESCRIPTION
Firestorm expects GitHub users to have a name and public email on GitHub
in order to use OAuth. This sets the name to the nickname and uses the
"noreply" email provided by GitHub as default values.

Resolves #40.