### PR TITLE
Webpack config + notification config for test/dev modes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,6 +12,9 @@ config :firestorm_web,
 # Should we send instrumentation to PryIn?
 config :firestorm_web, use_pryin: false
 
+# Start notification server in app start
+config :firestorm_web, notifications_enabled: true
+
 # Path prefixes from which to serve web assets (i.e. webpack dev mode path)
 config :firestorm_web,
   js_path_prefix: "http://localhost:8081",

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,6 +12,12 @@ config :firestorm_web,
 # Should we send instrumentation to PryIn?
 config :firestorm_web, use_pryin: false
 
+# Path prefixes from which to serve web assets (i.e. webpack dev mode path)
+config :firestorm_web,
+  js_path_prefix: "http://localhost:8081",
+  css_path_prefix: "http://localhost:8081",
+  image_path_prefix: "http://localhost:8081/static"
+
 # Configures the endpoint
 config :firestorm_web, FirestormWeb.Web.Endpoint,
   url: [host: "localhost"],

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -26,6 +26,12 @@ config :firestorm_web, FirestormWeb.Web.Endpoint,
 # this, but I'll deal with it later.
 config :firestorm_web, use_pryin: true
 
+# Path prefix from which to serve web assets (i.e. webpack dev mode path)
+config :firestorm_web,
+  js_path_prefix: "",
+  css_path_prefix: "",
+  image_path_prefix: ""
+
 config :phoenix, :template_engines,
   eex: Appsignal.Phoenix.Template.EExEngine,
   exs: Appsignal.Phoenix.Template.ExsEngine

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,6 +7,9 @@ config :firestorm_web, FirestormWeb.Web.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
+# Start notification server in app start
+config :firestorm_web, notifications_enabled: false
+
 # Configure your database
 config :firestorm_web, FirestormWeb.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/firestorm_web/application.ex
+++ b/lib/firestorm_web/application.ex
@@ -10,7 +10,8 @@ defmodule FirestormWeb.Application do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: FirestormWeb.Supervisor]
-    Supervisor.start_link(children(Mix.env), opts)
+    Supervisor.start_link(
+      children(Application.get_env(:firestorm_web, :notifications_enabled)), opts)
   end
 
   defp default_children() do
@@ -24,7 +25,7 @@ defmodule FirestormWeb.Application do
       worker(LruCache, [:oembed_cache, 5_000])
     ]
   end
-  defp children(:test) do
+  defp children(false) do
     default_children()
   end
   defp children(_) do

--- a/lib/firestorm_web/web/views/layout_view.ex
+++ b/lib/firestorm_web/web/views/layout_view.ex
@@ -77,18 +77,12 @@ defmodule FirestormWeb.Web.LayoutView do
   end
 
   def js_script_tag do
-    if Mix.env == :prod do
-      "<script src=\"/js/app.js\"></script>"
-    else
-      "<script src=\"http://localhost:8081/js/app.js\"></script>"
-    end
+    "<script src=\"" <> Application.get_env(:firestorm_web, :js_path_prefix)
+      <> "/js/app.js\"></script>"
   end
 
   def css_link_tag do
-    if Mix.env == :prod do
-      "<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/app.css\" />"
-    else
-      "<link rel=\"stylesheet\" type=\"text/css\" href=\"http://localhost:8081/css/app.css\" />"
-    end
+    "<link rel=\"stylesheet\" type=\"text/css\" href=\""
+      <> Application.get_env(:firestorm_web, :css_path_prefix) <> "/css/app.css\" />"
   end
 end

--- a/lib/firestorm_web/web/views/view_helpers.ex
+++ b/lib/firestorm_web/web/views/view_helpers.ex
@@ -7,11 +7,7 @@ defmodule FirestormWeb.Web.ViewHelpers do
   import Phoenix.HTML, only: [raw: 1]
 
   def image_path(path) do
-    if Mix.env == :prod do
-      "/images/#{path}"
-    else
-      "http://localhost:8081/static/images/#{path}"
-    end
+    Application.get_env(:firestorm_web, :image_path_prefix) <> "/images/#{path}"
   end
 
   defdelegate avatar_url(user, size \\ 256), to: User


### PR DESCRIPTION
Eliminate references to Mix.env which prevent execution in a release/prod mode. 
