### PR TITLE
Add API endpoint to create a post

### DIFF
--- a/lib/firestorm_web/emails.ex
+++ b/lib/firestorm_web/emails.ex
@@ -4,7 +4,7 @@ defmodule FirestormWeb.Emails do
   """
 
   import Bamboo.Email
-  import FirestormWeb.Web.Router.Helpers
+  import FirestormWeb.Web.Router.Helpers, only: [category_thread_url: 4]
   import Phoenix.HTML
   import Phoenix.HTML.Link
   alias FirestormWeb.Web.Endpoint

--- a/lib/firestorm_web/forums/forums.ex
+++ b/lib/firestorm_web/forums/forums.ex
@@ -80,6 +80,10 @@ defmodule FirestormWeb.Forums do
 
   """
   def create_user(attrs \\ %{}) do
+    attrs =
+      attrs
+      |> Map.put(:api_token, generate_api_token())
+
     %User{}
     |> user_changeset(attrs)
     |> Repo.insert()

--- a/lib/firestorm_web/forums/forums.ex
+++ b/lib/firestorm_web/forums/forums.ex
@@ -58,6 +58,11 @@ defmodule FirestormWeb.Forums do
   def get_user_by_username(username), do: Repo.get_by(User, %{username: username})
 
   @doc """
+  Gets a single user by api_token. Maybe.
+  """
+  def get_user_by_api_token(api_token), do: Repo.get_by(User, %{api_token: api_token})
+
+  @doc """
   Gets a single user by email address. Maybe.
   """
   def get_user_by_email(email), do: Repo.get_by(User, %{email: email})

--- a/lib/firestorm_web/forums/notification.ex
+++ b/lib/firestorm_web/forums/notification.ex
@@ -4,7 +4,8 @@ defmodule FirestormWeb.Forums.Notification do
   """
 
   use Ecto.Schema
-  import FirestormWeb.Web.Router.Helpers
+  import FirestormWeb.Web.Router.Helpers, only: [category_thread_url: 4]
+  alias FirestormWeb.Web.Router.Helpers
   alias FirestormWeb.Forums.{User, Thread, Post}
   alias FirestormWeb.Web.Endpoint
 

--- a/lib/firestorm_web/plugs/api_current_user.ex
+++ b/lib/firestorm_web/plugs/api_current_user.ex
@@ -1,0 +1,26 @@
+defmodule FirestormWeb.Web.Plugs.ApiCurrentUser do
+  @moduledoc """
+  A `Plug` to assign `:current_user` based on the authorization header containing a user's api token
+  """
+
+  import Plug.Conn
+  alias FirestormWeb.Forums
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    api_token =
+      conn
+      |> get_req_header("authorization")
+      |> hd()
+      |> String.replace("Bearer ", "")
+
+    case Forums.get_user_by_api_token(api_token) do
+      nil ->
+        conn
+      user ->
+        conn
+        |> assign(:current_user, user)
+    end
+  end
+end

--- a/lib/firestorm_web/plugs/api_current_user.ex
+++ b/lib/firestorm_web/plugs/api_current_user.ex
@@ -9,18 +9,20 @@ defmodule FirestormWeb.Web.Plugs.ApiCurrentUser do
   def init(options), do: options
 
   def call(conn, _opts) do
-    api_token =
-      conn
-      |> get_req_header("authorization")
-      |> hd()
-      |> String.replace("Bearer ", "")
+    case get_req_header(conn, "authorization") do
+      [] -> conn
+      [authorization|_] ->
+        api_token =
+          authorization
+          |> String.replace("Bearer ", "")
 
-    case Forums.get_user_by_api_token(api_token) do
-      nil ->
-        conn
-      user ->
-        conn
-        |> assign(:current_user, user)
+        case Forums.get_user_by_api_token(api_token) do
+          nil ->
+            conn
+          user ->
+            conn
+            |> assign(:current_user, user)
+        end
     end
   end
 end

--- a/lib/firestorm_web/web/controllers/api/v1/post_controller.ex
+++ b/lib/firestorm_web/web/controllers/api/v1/post_controller.ex
@@ -1,0 +1,31 @@
+defmodule FirestormWeb.Web.Api.V1.PostController do
+  use FirestormWeb.Web, :controller
+  alias FirestormWeb.{
+    Forums,
+    Markdown
+  }
+
+  def create(conn, %{"post" => post_params, "thread_id" => thread_id}) do
+    with thread when not is_nil(thread) <- Forums.get_thread(thread_id),
+         user when not is_nil(user) <- conn.assigns[:current_user],
+         {:ok, post} <- Forums.create_post(thread, user, %{body: post_params["body"]}) do
+      conn
+      |> put_status(201)
+      |> json(%{
+           data: %{
+             body: Markdown.render(post.body),
+             id: post.id,
+             thread_id: thread_id
+           }
+         })
+    else
+      x ->
+        IO.inspect x
+
+        conn
+        |> put_status(:unprocessable_entity)
+        # FIXME: Send back errors that are meaningful
+        |> json(%{"error" => "Failed to create post"})
+    end
+  end
+end

--- a/lib/firestorm_web/web/router.ex
+++ b/lib/firestorm_web/web/router.ex
@@ -14,6 +14,7 @@ defmodule FirestormWeb.Web.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug FirestormWeb.Web.Plugs.ApiCurrentUser
   end
 
   scope "/auth", FirestormWeb.Web do
@@ -51,6 +52,7 @@ defmodule FirestormWeb.Web.Router do
 
     resources "/preview", PreviewController, only: [:create]
     resources "/upload_signature", UploadSignatureController, only: [:create]
+    resources "/posts", PostController, only: [:create]
     post "/auth/identity", AuthController, :identity
   end
 

--- a/test/web/controllers/api/v1/post_controller_test.exs
+++ b/test/web/controllers/api/v1/post_controller_test.exs
@@ -1,13 +1,26 @@
 defmodule FirestormWeb.Web.Api.V1.PostControllerTest do
   use FirestormWeb.Web.ConnCase
-  alias FirestormWeb.Markdown
+  alias FirestormWeb.{
+    Markdown,
+    Forums
+  }
 
   test "POST /", %{conn: conn} do
+    {:ok, elixir} = Forums.create_category(%{title: "Elixir"})
+    {:ok, bob} =
+      Forums.login_or_register_from_identity(%{username: "bob", password: "password"})
+    {:ok, otp_is_cool} = Forums.create_thread(elixir, bob, %{title: "OTP is cool", body: "Don't you think?"})
+
     post = %{
       "body" => "this is **neat**",
     }
-    conn = post conn, "/api/v1/preview", post: post
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{bob.api_token}")
+      |> post("/api/v1/posts", post: post, thread_id: otp_is_cool.id)
+
     response = json_response(conn, 201)["data"]
-    assert response["html"] == Markdown.render(post["body"])
+    assert response["body"] == Markdown.render(post["body"])
   end
 end

--- a/test/web/controllers/api/v1/post_controller_test.exs
+++ b/test/web/controllers/api/v1/post_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule FirestormWeb.Web.Api.V1.PostControllerTest do
+  use FirestormWeb.Web.ConnCase
+  alias FirestormWeb.Markdown
+
+  test "POST /", %{conn: conn} do
+    post = %{
+      "body" => "this is **neat**",
+    }
+    conn = post conn, "/api/v1/preview", post: post
+    response = json_response(conn, 201)["data"]
+    assert response["html"] == Markdown.render(post["body"])
+  end
+end


### PR DESCRIPTION
- Add the ability to create a post by hitting a posts API endpoint.
- Add an ApiCurrentUser plug to fetch a user from the authorization
  header