### PR TITLE
Bump to v0.10.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FirestormWeb.Mixfile do
   def project do
     [
       app: :firestorm_web,
-      version: "0.9.1",
+      version: "0.10.0",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
Given that the required version of elixir was bumped pretty dramatically
and all of the dependencies, it seemed fitting to call it a new
pre-release minor version.