### PR TITLE
1. Update dependencies for newer elixir and also use new phoenix nami…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM elixir:1.5.2
+FROM elixir:1.7.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mix local.hex --force
 RUN mix local.rebar --force
-RUN mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez --force
+RUN mix archive.install https://github.com/phoenixframework/archives/raw/master/phx_new.ez --force
 
+RUN apt-get update
 RUN apt-get install -y -q nodejs
 
 RUN mkdir /firestorm
 ADD . /firestorm
 WORKDIR /firestorm
+RUN mix deps.get


### PR DESCRIPTION
1. Update dependencies for newer elixir and also use new phoenix naming conventions.
2. Ensure that apt has its package lists before attempting to fetch nodejs (otherwise it fails).
3. Fetch mix deps before ecto operations (otherwise they fail).