### PR TITLE
Update webpack-dev-server

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -39,7 +39,7 @@
     "uglify-js-brunch": "2.1.1",
     "url-loader": "^0.5.8",
     "webpack": "^2.5.0",
-    "webpack-dev-server": "^2.4.5",
+    "webpack-dev-server": "^3.1.11",
     "write-file-webpack-plugin": "^4.0.2"
   }
 }


### PR DESCRIPTION
Update webpack-dev-server because of: https://nvd.nist.gov/vuln/detail/CVE-2018-14732